### PR TITLE
Support parenthesized expressions from FJ paper

### DIFF
--- a/examples/success/4.java
+++ b/examples/success/4.java
@@ -1,0 +1,34 @@
+class A extends Object {
+    A () {
+        super();
+    }
+}
+
+class B extends Object {
+    B() {
+        super();
+    }
+}
+
+class Pair extends Object {
+    Object fst;
+    Object snd;
+    Pair(Object fst, Object snd) {
+        super();
+        this.fst=fst;
+        this.snd=snd;
+    }
+    Pair setfst(Object newfst) {
+        return new Pair(newfst, this.snd);
+    }
+}
+
+class Demo extends Object {
+    Demo() {
+        super();
+    }
+    B demoMethod() {
+        // This expression evaluates to the expression new B()
+        return (B)((Pair)new Pair(new Pair(new A(), new B()), new A()).fst).snd;
+    }
+}

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -92,13 +92,17 @@ method_definition :
       }
     }
 
+parenthesized_expression :
+  LPAREN expression RPAREN { $2 }
+
 expression :
     expression_1 { $1 }
+  | parenthesized_expression { $1 }
   | NEW ID LPAREN argument_list_opt RPAREN { New ($2, $4) }
   | LPAREN ID RPAREN expression { Cast ($2, $4) }
 
 expression_1 :
     ID { Var $1 }
   | THIS { Var (Id.make "this") }
-  | expression_1 PERIOD ID { FieldGet ($1, $3) }
-  | expression_1 PERIOD ID LPAREN argument_list_opt RPAREN { MethodCall ($1, $3, $5) }
+  | expression PERIOD ID { FieldGet ($1, $3) }
+  | expression PERIOD ID LPAREN argument_list_opt RPAREN { MethodCall ($1, $3, $5) }

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -380,7 +380,8 @@ let check_method table env klass meth =
   if not (is_subclass table (Method.return_type meth) ty) then
     raise (Type_error (
       Method.position meth,
-      "invalid method return type: " ^ (Method.name meth)));
+      sprintf "invalid return type for %s (got: %s, expected: %s)"
+        (Method.name meth) (Method.return_type meth) ty));
   check_method_override table klass meth
 
 (* クラスのすべてのメソッドのチェック *)


### PR DESCRIPTION
Hi, thank you very much for this project.

I suggest a small improvement that allows the parser to handle more complex examples from the original paper. 

For example, this allows to correctly parse and typecheck the following expression (FJ, page 5):

![image](https://user-images.githubusercontent.com/12023585/89731225-fb334680-da4d-11ea-9e6f-fd6d1067fdaf.png)
